### PR TITLE
Fix application crash when trying to install this add-on

### DIFF
--- a/outlook-add-in-on-send/Contoso Message Body Checker.xml
+++ b/outlook-add-in-on-send/Contoso Message Body Checker.xml
@@ -12,6 +12,9 @@
   <DefaultLocale>en-us</DefaultLocale>
   <DisplayName DefaultValue="Contoso Message Body Checker" />
   <Description DefaultValue="Contoso Message Body Checker" />
+  <IconUrl DefaultValue="https://localhost:3000/add-ins/assets/icon-32.png"/>
+  <HighResolutionIconUrl DefaultValue="https://localhost:3000/add-ins/assets/icon-80.png"/>
+  <SupportUrl DefaultValue="https://localhost:3000/SupportUrl.html" />
 
   <Requirements>
     <Sets DefaultMinVersion="1.1">

--- a/outlook-add-in-on-send/Contoso Subject and CC Checker.xml
+++ b/outlook-add-in-on-send/Contoso Subject and CC Checker.xml
@@ -12,6 +12,9 @@
   <DefaultLocale>en-us</DefaultLocale>
   <DisplayName DefaultValue="Contoso Subject and CC Checker" />
   <Description DefaultValue="Contoso Subject and CC Checker" />
+  <IconUrl DefaultValue="https://localhost:3000/add-ins/assets/icon-32.png"/>
+  <HighResolutionIconUrl DefaultValue="https://localhost:3000/add-ins/assets/icon-80.png"/>
+  <SupportUrl DefaultValue="https://localhost:3000/SupportUrl.html" />
 
   <Requirements>
     <Sets DefaultMinVersion="1.1">


### PR DESCRIPTION
Fix application crash when trying to install this add-on in Outlook for Mac.

If we try to just install this Add-in in Outlook for Mac, we will get a crash of the application.
After checking the manifest with command **npx office-addin-manifest**, I found the missing tags:
_SupportUrl_, _IconUrl_ and _HighResolutionIconUrl_
([Verification Instructions](https://docs.microsoft.com/en-us/office/dev/add-ins/testing/troubleshoot-manifest))
After adding tags, the add-in is installed correctly.
Hope this saves someone time.